### PR TITLE
feat: 음식점 목록 관련 recoil atom & selector 추가 (#03)

### DIFF
--- a/src/recoil/Restaurant/atoms.ts
+++ b/src/recoil/Restaurant/atoms.ts
@@ -1,0 +1,12 @@
+import { atom } from 'recoil';
+import type { RestaurantType } from '../../Type/interface';
+
+export const restaurantListAtom = atom<RestaurantType[]>({
+  key: 'restaurantListAtom',
+  default: [],
+});
+
+export const userLocationAtom = atom<string | undefined>({
+  key: 'userLocationAtom',
+  default: undefined,
+});

--- a/src/recoil/Restaurant/selectors.ts
+++ b/src/recoil/Restaurant/selectors.ts
@@ -1,0 +1,25 @@
+import { selector } from 'recoil';
+import type { RestaurantType } from '../../Type/interface';
+import { restaurantListAtom, userLocationAtom } from './atoms';
+
+export const filteredRestaurantListSelector = selector<RestaurantType[]>({
+  key: 'filteredRestaurantListSelector',
+  get: ({ get }) => {
+    const restaurantList = get(restaurantListAtom);
+    const userLocation = get(userLocationAtom);
+    let filteredList: RestaurantType[] = [];
+
+    if (
+      userLocation &&
+      restaurantList?.length !== undefined &&
+      restaurantList.length !== 0
+    ) {
+      filteredList = restaurantList.filter(
+        (restaurant) =>
+          userLocation === `부산 ${restaurant.gugun.split(' ')[1]}`
+      );
+    }
+
+    return filteredList;
+  },
+});


### PR DESCRIPTION
### PR 타입
-[feat] : 음식점 목록 관련 recoil atom & selector 추가

### 구현 사항
- 음식점 목록, 사용자 현재 위치 atom 생성
- 음식점 목록, 사용자 현재 위치 atom을 사용하여 사용자 주변 음식점을 가져오는 selector 생성

### 특이 사항
- (#2) 재업로드